### PR TITLE
Fix opengl32core profile issues

### DIFF
--- a/HeartLibrary/src/main/java/jme3utilities/debug/SkeletonVisualizer.java
+++ b/HeartLibrary/src/main/java/jme3utilities/debug/SkeletonVisualizer.java
@@ -50,14 +50,15 @@ import com.jme3.scene.Spatial;
 import com.jme3.scene.control.AbstractControl;
 import com.jme3.texture.Texture;
 import com.jme3.util.clone.Cloner;
-import java.io.IOException;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.logging.Logger;
 import jme3utilities.MyAsset;
 import jme3utilities.MySpatial;
 import jme3utilities.SubtreeControl;
 import jme3utilities.Validate;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Logger;
 
 /**
  * A SubtreeControl to visualize a Skeleton.
@@ -90,7 +91,7 @@ public class SkeletonVisualizer extends SubtreeControl {
     /**
      * default width for link lines (in pixels)
      */
-    final private static float defaultLineWidth = 2f;
+    final private static float defaultLineWidth = 1f;
     /**
      * child position of the heads geometry in the subtree Node
      */
@@ -191,6 +192,7 @@ public class SkeletonVisualizer extends SubtreeControl {
     public SkeletonVisualizer(AssetManager assetManager,
             AbstractControl subject) {
         super();
+        System.out.println("############ ksdflmqsjkdflmqsjfmldsqjflsdq ###############");
         Validate.nonNull(assetManager, "asset manager");
 
         lineMaterial = MyAsset.createMulticolor2Material(assetManager,

--- a/HeartLibrary/src/main/java/jme3utilities/debug/SkeletonVisualizer.java
+++ b/HeartLibrary/src/main/java/jme3utilities/debug/SkeletonVisualizer.java
@@ -50,15 +50,14 @@ import com.jme3.scene.Spatial;
 import com.jme3.scene.control.AbstractControl;
 import com.jme3.texture.Texture;
 import com.jme3.util.clone.Cloner;
-import jme3utilities.MyAsset;
-import jme3utilities.MySpatial;
-import jme3utilities.SubtreeControl;
-import jme3utilities.Validate;
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Logger;
+import jme3utilities.MyAsset;
+import jme3utilities.MySpatial;
+import jme3utilities.SubtreeControl;
+import jme3utilities.Validate;
 
 /**
  * A SubtreeControl to visualize a Skeleton.
@@ -192,7 +191,6 @@ public class SkeletonVisualizer extends SubtreeControl {
     public SkeletonVisualizer(AssetManager assetManager,
             AbstractControl subject) {
         super();
-        System.out.println("############ ksdflmqsjkdflmqsjfmldsqjflsdq ###############");
         Validate.nonNull(assetManager, "asset manager");
 
         lineMaterial = MyAsset.createMulticolor2Material(assetManager,

--- a/HeartLibrary/src/main/resources/MatDefs/wireframe/multicolor.j3md
+++ b/HeartLibrary/src/main/resources/MatDefs/wireframe/multicolor.j3md
@@ -36,11 +36,11 @@ MaterialDef multicolor {
         Defines {
             NUM_BONES : NumberOfBones
         }
-        FragmentShader GLSL110: Shaders/wireframe/multicolor.frag
+        FragmentShader GLSL310 GLSL300 GLSL100 GLSL150: Shaders/wireframe/multicolor.frag
         RenderState {
             Wireframe On
         }
-        VertexShader GLSL110:   Shaders/wireframe/multicolor.vert
+        VertexShader GLSL310 GLSL300 GLSL100 GLSL150:   Shaders/wireframe/multicolor.vert
         WorldParameters {
             ViewMatrix
             ViewProjectionMatrix

--- a/HeartLibrary/src/main/resources/MatDefs/wireframe/multicolor2.j3md
+++ b/HeartLibrary/src/main/resources/MatDefs/wireframe/multicolor2.j3md
@@ -45,11 +45,11 @@ MaterialDef multicolor2 {
             POINT_SHAPE : PointShape
             VERTEX_COLOR : UseVertexColor
         }
-        FragmentShader GLSL120: Shaders/wireframe/multicolor2.frag
+        FragmentShader GLSL310 GLSL300 GLSL100 GLSL110 GLSL150: Shaders/wireframe/multicolor2.frag
         RenderState {
             Wireframe On
         }
-        VertexShader GLSL120:   Shaders/wireframe/multicolor2.vert
+        VertexShader GLSL310 GLSL300 GLSL100 GLSL110 GLSL150:   Shaders/wireframe/multicolor2.vert
         WorldParameters {
             ViewMatrix
             ViewProjectionMatrix

--- a/HeartLibrary/src/main/resources/Shaders/filter/ContrastAdjustment15.frag
+++ b/HeartLibrary/src/main/resources/Shaders/filter/ContrastAdjustment15.frag
@@ -29,6 +29,7 @@
  * fragment shader used by ContrastAdjustment.j3md
  */
 
+#import "Common/ShaderLib/GLSLCompat.glsllib"
 #import "Common/ShaderLib/MultiSample.glsllib"
 
 in vec2 texCoord;


### PR DESCRIPTION
This fixes the `TestMultiColor` and `TestSkeletonVisualizer` tests.

In `SkeletonVisualizer` I adapted the default line width to 1. This is the only width that is _guaranteed_ to work. See [spec](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glLineWidth.xhtml). This way you are still able to change it if your hardware supports it but is the default guaranteed to work. 

I was unable to fix the `TestContrast` as this is using the `#import "Common/ShaderLib/MultiSample.glsllib"` library.
This library uses the [deprecated](https://stackoverflow.com/questions/26266198/glsl-invalid-call-of-undeclared-identifier-texture2d#comment41239149_26266341) `texture2D` function instead of the new `texture` function.

I was able to test the fix, by removing the import and just copy-pasting the content of the lib above the shader and replacing the `texture2D` function by the `texture` function.

~~This is however not a proper way to fix it. We should fix it at the source. I'll create a PR for it at the jMonkeyEngine repo.~~
Edit: see below comment for a fix.